### PR TITLE
Add flag to relabel volumes to private unshared

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   database:
     image: neo4j:latest
     volumes:
-      - ./data:/data
-      - ./logs:/logs
-      - ./import:/var/lib/neo4j/import
+      - ./data:/data:Z
+      - ./logs:/logs:Z
+      - ./import:/var/lib/neo4j/import:Z
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
Previously volumes could not be mounted on systems that enforce labelling systems such as SELinux. This flag reassigns labels on volumes so that the host can manage volumes correctly and mount successfully. See docker-run(1).